### PR TITLE
provide rjsx-minor-mode

### DIFF
--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -52,13 +52,24 @@ parsing supports the magic `rjsx-electric-lt' and
   :group 'rjsx-mode)
 
 ;;;###autoload
+(define-minor-mode rjsx-minor-mode
+  "Minor mode for JSX AST parsing"
+  :group 'rjsx-mode
+  :lighter " jsx "
+  (if (derived-mode-p 'rjsx-mode)
+      (setq rjsx-minor-mode nil)
+    (if rjsx-minor-mode
+        (js2-minor-mode-enter)
+      (js2-minor-mode-exit))))
+
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jsx\\'" . rjsx-mode))
 
 (defun rjsx-parse-xml-initializer (orig-fun)
   "Dispatch the xml parser based on variable `rjsx-mode' being active or not.
 This function is used to advise `js2-parse-xml-initializer' (ORIG-FUN) using
 the `:around' combinator.  JS2-PARSER is the original XML parser."
-  (if (eq major-mode 'rjsx-mode)
+  (if (or (eq major-mode 'rjsx-mode) (member 'rjsx-minor-mode minor-mode-list))
       (rjsx-parse-top-xml)
     (apply orig-fun nil)))
 

--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -52,28 +52,21 @@ parsing supports the magic `rjsx-electric-lt' and
   :group 'rjsx-mode)
 
 ;;;###autoload
-(define-minor-mode rjsx-minor-mode
-  "Minor mode for JSX AST parsing"
-  :group 'rjsx-mode
-  :lighter " jsx "
-  (if (derived-mode-p 'rjsx-mode)
-      (setq rjsx-minor-mode nil)
-    (if rjsx-minor-mode
-        (js2-minor-mode-enter)
-      (js2-minor-mode-exit))))
-
-;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jsx\\'" . rjsx-mode))
 
 (defun rjsx-parse-xml-initializer (orig-fun)
   "Dispatch the xml parser based on variable `rjsx-mode' being active or not.
 This function is used to advise `js2-parse-xml-initializer' (ORIG-FUN) using
 the `:around' combinator.  JS2-PARSER is the original XML parser."
-  (if (or (eq major-mode 'rjsx-mode) (member 'rjsx-minor-mode minor-mode-list))
+  (if (or (eq major-mode 'rjsx-mode) rjsx-jsx-enabled-p)
       (rjsx-parse-top-xml)
     (apply orig-fun nil)))
 
-(advice-add 'js2-parse-xml-initializer :around #'rjsx-parse-xml-initializer)
+;;;###autoload
+(defun rjsx-enable-parser ()
+  (advice-add 'js2-parse-xml-initializer :around #'rjsx-parse-xml-initializer))
+
+(rjsx-enable-parser)
 
 (defun rjsx-unadvice-js2 ()
   "Remove the rjsx advice on the js2 parser.  This will cause rjsx to stop working globally."


### PR DESCRIPTION
I'm not sure if this is the cleanest way to do it or if there may be unexpected side effect.
The idea is to provide a minor-mode similar to js2-minor-mode in order to allow the usage of packages depending on the js2/rjsx AST to work in other major modes (e.g. using js2-refactor in web-mode)

I tired it locally and seems to work with js2-refactor