### PR TITLE
Fix #46 Support JSX comments

### DIFF
--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -1017,7 +1017,7 @@ PREDICATE."
                    (rjsx-node-p (js2-node-parent parent))
                    (or (rjsx-text-p node) (rjsx-node-p node)))
           (let* ((expr-start (js2-node-abs-pos parent))
-                 (expr-end (js2-node-abs-end parent))
+                 (expr-end (+ expr-start (js2-node-len parent)))
                  (body-start (1+ expr-start))
                  (body-end (1- expr-end))
                  (body-length (- body-end body-start)))

--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -32,6 +32,8 @@
 
 (require 'cl-lib)
 (require 'js2-mode)
+(eval-when-compile (require 'subr-x))
+(require 'newcomment)
 
 (defgroup rjsx-mode nil
   "Support for JSX."
@@ -49,7 +51,14 @@ parsing supports the magic `rjsx-electric-lt' and
 (define-derived-mode rjsx-mode js2-jsx-mode "RJSX"
   "Major mode for editing JSX files."
   :lighter ":RJSX"
-  :group 'rjsx-mode)
+  :group 'rjsx-mode
+  (setq-local comment-use-syntax nil)
+  (setq-local comment-start-skip "[[:space:]]*\\(//+\\|{?/\\*+\\)")
+  ;; \n is included to get arround `comment-normalize-vars' and `comment-only-p'
+  (setq-local comment-end-skip "\\(\\*+/}?[[:space:]]*\\)\n?\\|\n")
+  (setq-local comment-region-function 'rjsx-comment-region-function)
+  (setq-local uncomment-region-function 'rjsx-uncomment-region-function)
+  (setq-local comment-quote-nested-function 'rjsx-comment-quote-nested-function))
 
 ;;;###autoload
 (define-minor-mode rjsx-minor-mode
@@ -953,6 +962,247 @@ NEW-NAME is the name to give the tag."
 
 (define-key rjsx-mode-map (kbd "C-c C-r") 'rjsx-rename-tag-at-point)
 
+;; Comment handling
+(defun rjsx-ancestor (node predicate)
+  "Find an ancestor of NODE satisfying PREDICATE.
+
+Search upwards from the parent of NODE for an ancestor where
+PREDICATE returns t.  Returns nil if no ancestor satisfies
+PREDICATE."
+  (let ((ancestor (js2-node-parent node)))
+    (while (and ancestor
+                (not (funcall predicate ancestor)))
+      (setq ancestor (js2-node-parent ancestor)))
+    ancestor))
+
+(defun rjsx-comment-region-function (beg end &optional arg)
+  (js2-mode-wait-for-parse
+   (lambda ()
+     (let* ((node (js2-node-at-point beg))
+            (in-jsx (or (rjsx-node-p node)
+                        (rjsx-ancestor node 'rjsx-node-p)))
+            (use-jsx-comment (and (rjsx-node-p (js2-node-parent node))
+                                  (or (rjsx-text-p node)
+                                      (and (rjsx-node-p node)
+                                           (= (js2-node-abs-pos node) beg))))))
+       (cond (use-jsx-comment
+              (let ((comment-start "{/*")
+                    (comment-end "*/}"))
+                (comment-normalize-vars)
+                (comment-region-default beg end arg)))
+             (in-jsx
+              (let ((comment-start "/*")
+                    (comment-end "*/"))
+                (comment-normalize-vars)
+                (if (rjsx-wrapped-expr-p node)
+                    (if (js2-empty-expr-node-p (rjsx-wrapped-expr-child node))
+                        (let ((comment-start "{/*")
+                              (comment-end "*/}"))
+                          (comment-normalize-vars)
+                          (comment-region-default beg end arg))
+                      (comment-region-default (1+ beg) (1- end) arg))
+                  (comment-region-default beg end arg))))
+             (t (comment-region-default beg end arg)))))))
+
+(defun rjsx-maybe-unwrap-expr (beg end)
+  (save-excursion
+    (save-restriction
+      (js2-reparse)
+      (goto-char beg)
+      (skip-chars-forward "[:space:]\n" end)
+      (let* ((node (js2-node-at-point (point)))
+             (parent (js2-node-parent node)))
+        (when (and parent
+                   (rjsx-wrapped-expr-p parent)
+                   (rjsx-node-p (js2-node-parent parent))
+                   (or (rjsx-text-p node) (rjsx-node-p node)))
+          (let* ((expr-start (js2-node-abs-pos parent))
+                 (expr-end (js2-node-abs-end parent))
+                 (body-start (1+ expr-start))
+                 (body-end (1- expr-end))
+                 (body-length (- body-end body-start)))
+            (when (and (comment-only-p body-start beg)
+                       (comment-only-p end body-end))
+              (goto-char expr-start)
+              (delete-char 1)
+              (forward-char body-length)
+              (delete-char 1))))))))
+
+(defun rjsx-uncomment-region-function (beg end &optional _)
+  (js2-mode-wait-for-parse
+   (lambda ()
+     (goto-char beg)
+     (setq end (copy-marker end))
+     (let (cs ts te ce matched-start)
+       ;; find comment start
+       (while (and (<= (point) end)
+                   (setq matched-start
+                         (and (re-search-forward comment-start-skip end t 1)
+                              (match-string-no-properties 0))))
+         ;; delete comment-start
+         (setq cs (match-beginning 1))
+         (setq ts (match-end 1))
+         (goto-char cs)
+         (delete-region cs ts)
+
+         ;; delete comment-padding start
+         (when (and comment-padding (looking-at (regexp-quote comment-padding)))
+           (delete-region (point) (+ (point) (length comment-padding))))
+
+         ;; find comment end
+         (when (re-search-forward (if (string-match "//+" matched-start) "\n" "\\*/}?") end t 1)
+           (setq te (or (match-beginning 1) (match-beginning 0)))
+           (setq ce (or (match-end 1) (match-end 0)))
+           (goto-char te)
+
+           ;; delete commend-end if it's not a newline
+           (unless (string= "\n" (match-string-no-properties 0))
+             (delete-region te ce)
+
+             ;; delete comment-padding end
+             (when comment-padding
+               (backward-char (length comment-padding))
+               (when (looking-at (regexp-quote comment-padding))
+                 (delete-region (point) (+ (point) (length comment-padding))))))
+
+           ;; unescape inner comments if any
+           (save-restriction
+             (narrow-to-region cs (point))
+             (comment-quote-nested "{/*" "*/}" t)))))
+
+     (rjsx-maybe-unwrap-expr beg end)
+
+     (set-marker end nil))))
+
+(defun rjsx-comment-quote-nested-function (_ __ unp)
+  (let ((re (concat "\\*\\(\\\\" (if unp "+" "*") "\\)/}?"
+                    "\\|"
+                    "{?/\\(\\\\" (if unp "+" "*") "\\)\\*")))
+    (goto-char (point-min))
+    (while (re-search-forward re (point-max) t 1)
+      (let ((ceme (match-end 1))
+            (csme (match-end 2)))
+        (goto-char (or ceme csme))
+        (if (and unp (>= (length (or (match-string-no-properties 1)
+                                     (match-string-no-properties 2)))
+                         1))
+            (delete-char -1)
+          (insert "\\"))))))
+
+;;;###autoload
+(defun rjsx-comment-dwim (arg)
+  "RJSX implementation of `comment-dwim'. If called on a region,
+this function delegates to `comment-or-uncomment-region'. If the
+point is not in a JSX context, it delegates to the
+`comment-dwim', otherwise it will comment the JSX AST node at
+point using the apppriate comment delimiters.
+
+For example: If point is on a JSX attribute or JSX expression, it
+will comment the entire attribute using \"/* */\". , otherwise if
+it's on a descendent JSX Element, it will use \"{/* */}\"
+instead."
+  (interactive "*P")
+  (js2-mode-wait-for-parse
+   (lambda ()
+     (if (use-region-p)
+         (comment-or-uncomment-region (region-beginning) (region-end) arg)
+       (save-excursion
+         (when (looking-at "[[:space:]]")
+           (forward-whitespace 1))
+         (let ((node (js2-node-at-point)))
+           (cond
+            ;; If inside a regular JS comment node, uncomment the node
+            ((js2-comment-at-point)
+             (uncomment-region (js2-node-abs-pos node) (js2-node-abs-end node)))
+            ;; If looking at a commented JSXAttribute value, forward one char to
+            ;; uncomment the body
+            ((and (looking-at comment-start-skip)
+                  (looking-at "{")
+                  (rjsx-attr-p (js2-node-parent node)))
+             (forward-char 1)
+             (rjsx-comment-dwim arg))
+            ;; If the entire line is a comment, uncomment it
+            ((and (comment-only-p (point) (line-end-position))
+                  (not (looking-at "[[:space:]]*$")))
+             (uncomment-region (point) (line-end-position)))
+            ;; If looking at JSXText, comment the current line
+            ((rjsx-text-p node)
+             (let ((comment-start "{/*")
+                   (comment-end "*/}"))
+               (comment-line 1)))
+            ;; If looking at a JSXAttribute or a JSXSpreadAttribute, comment the
+            ;; entire attribute with C-style comment
+            ((or (rjsx-spread-p node)
+                 (rjsx-ancestor node 'rjsx-spread-p)
+                 (rjsx-attr-p node)
+                 (and (js2-name-node-p node)
+                      (rjsx-identifier-p (js2-node-parent node))
+                      (rjsx-attr-p (js2-node-parent (js2-node-parent node))))
+                 (and (rjsx-identifier-p node)
+                      (rjsx-attr-p (js2-node-parent node)))
+                 (and (js2-string-node-p node)
+                      (rjsx-attr-p (js2-node-parent node))))
+             (let ((node (or (and (rjsx-spread-p node) node)
+                             (rjsx-ancestor node 'rjsx-spread-p)
+                             (and (rjsx-attr-p node) node)
+                             (rjsx-ancestor node 'rjsx-attr-p)))
+                   (comment-start "/*")
+                   (comment-end "*/"))
+               (comment-region
+                (js2-node-abs-pos node)
+                (js2-node-abs-end node) arg)))
+            ;; If looking at a JSXElement or JSXFragment, comment the entire
+            ;; node with JSX comment if it's a child of one of the above,
+            ;; otherwise just comment with C-style comment.
+            ((or (rjsx-node-p node)
+                 (rjsx-closing-tag-p node)
+                 (rjsx-member-p node)
+                 (rjsx-ancestor node 'rjsx-member-p))
+             (let* ((node (or (and (rjsx-node-p node) node)
+                              (rjsx-ancestor node 'rjsx-node-p)))
+                    (parent-node-p (rjsx-node-p (js2-node-parent node)))
+                    (closing (rjsx-node-closing-tag node))
+                    (comment-start (if parent-node-p "{/*" "/*"))
+                    (comment-end (if parent-node-p "*/}" "*/")))
+               (comment-region
+                (js2-node-abs-pos node)
+                (js2-node-abs-end (or closing node)) arg)))
+            ;; If looking at a JSX {expression} or is inside a JSX expression,
+            ;; comment the body with regular C-style comment. If the body is
+            ;; already commented, uncomment it. If on a multi line JSX
+            ;; expression, just comment the line.
+            ((or (rjsx-wrapped-expr-p node)
+                 (rjsx-ancestor node 'rjsx-wrapped-expr-p))
+             (let* ((expr (or (and (rjsx-wrapped-expr-p node) node)
+                              (rjsx-ancestor node 'rjsx-wrapped-expr-p)))
+                    ;; Can only happen as a child of an element or fragment, an
+                    ;; empty JSX expression attribute value will result in an
+                    ;; error node
+                    (expr-empty (js2-empty-expr-node-p (rjsx-wrapped-expr-child expr)))
+                    (body-start (1+ (js2-node-abs-pos expr)))
+                    (body-end (1- (js2-node-abs-end expr)))
+                    (expr-child-of-node (rjsx-node-p (js2-node-parent expr))))
+               ;; If the body is all comment, uncomment it, otherwise if it's
+               ;; empty, wrap it with a JSX comment
+               (if (and expr-child-of-node expr-empty)
+                   (if (or (= (1+ (js2-node-abs-pos expr)) (js2-node-abs-end expr)) ;; {}
+                           (string-blank-p (buffer-substring-no-properties body-start body-end)))
+                       (let ((comment-start "{/*")
+                             (comment-end "*/}"))
+                         (comment-region (js2-node-abs-pos expr) (js2-node-abs-end expr) arg))
+                     (when (comment-only-p body-start body-end)
+                       (uncomment-region body-start body-end arg)))
+                 ;; If in a multi-line JSX expression, comment the line
+                 (if (> (count-lines body-start body-end) 1)
+                     (comment-dwim arg)
+                   ;; Otherwise comment the entire body
+                   (let ((comment-start "/*")
+                         (comment-end "*/"))
+                     (comment-region body-start body-end arg))))))
+            ;; Otherwise just delegate to (comment-dwim)
+            (t (comment-dwim arg)))))))))
+
+(define-key rjsx-mode-map [remap comment-dwim] 'rjsx-comment-dwim)
 
 (provide 'rjsx-mode)
 ;;; rjsx-mode.el ends here


### PR DESCRIPTION
This PR implements a number of comment commands suitable for `rjsx-mode`. 

`rjsx-comment-dwim` generally does what you expect - tries really hard to keep your JSX code valid by deciding what kind of `comment-start` and `comment-end` delimiters to use. If point is on a top-level JSX element, it'll just comment the whole node with `/* */`. If point is on a child element or text node, the child is commented with `{/* */}`. If point is on or inside a JSX expression, the body of the JSX expression is commented with `/* */`. If point  is on or before a JSX attribute, the entire attribute is commented with `/* */`.

This PR also provides an implementation of `comment-region-function`, `uncomment-region-function` and `comment-quote-nested-function` to support `rjsx-comment-dwim`.

There's a shit ton of tests included. Generally, `rjsx-comment-dwim` will just do what you expect. In the few edge cases that it doesn't, you can cycle the comments delimiters until you get what you want, or by moving point one character before or after its current position before `M-;`

I think this PR is so good, I've remapped `comment-dwim` to `rjsx-comment-dwim` when `rjsx-mode` is activated.

P.S. This is some of the ugliest and nastiest code I've ever written, and it's by no means easy as there are a LOT of cases to take care of and involves quite a number of regular expression hacks. I really hate `newcomment` and these stupid `comment-` global variables.