### PR TITLE
Indentation Fixes

### DIFF
--- a/rjsx-tests.el
+++ b/rjsx-tests.el
@@ -997,6 +997,55 @@ Currently only forms with syntax errors are supported.
 
 
 ;; Indentation
+(ert-deftest rjsx-indent-region ()
+  (ert-with-test-buffer (:name 'rjsx-indent-region)
+    (let ((fixture "(
+  <div>
+                {
+[1,2,3].map(num => {
+       return (<div/>);
+})
+}
+       <div
+id=\"1\"
+>
+1
+  <img
+ src=\"\"
+   alt=\"\"
+      wtf={() => (
+      <div>whatever</div>
+           )}
+ />
+    </div>
+</div>
+)")
+          (expected "(
+    <div>
+        {
+            [1,2,3].map(num => {
+                return (<div/>);
+            })
+        }
+        <div
+            id=\"1\"
+        >
+            1
+            <img
+                src=\"\"
+                alt=\"\"
+                wtf={() => (
+                    <div>whatever</div>
+                )}
+            />
+        </div>
+    </div>
+)"))
+      (insert fixture)
+      (rjsx-mode)
+      (js2-reparse)
+      (indent-region (point-min) (point-max))
+      (should (string= (buffer-substring-no-properties (point-min) (point-max)) expected)))))
 
 (ert-deftest rjsx-indentation-1 ()
   "Regression test for #67."


### PR DESCRIPTION
~# Merge after #72~

~## [Diff](https://github.com/wyuenho/rjsx-mode/compare/jsx-comments...wyuenho:indent-after-jsx-expr)~

Fixes:
- mooz/js2-mode#490
- mooz/js2-mode#482
- mooz/js2-mode#462
- mooz/js2-mode#451

Similar to `js-jsx-indent-line`, but fixes indentation bug with JSXElement after a JSX expression and arrow function. In addition, the > of a multi-line open tag and the /> of a multi-line self-closing tag are aligned to the beginning <. This function also ensures everything inside a JSX context is indented according to `js-indent-level` using spaces, this is due to the limitation of `sgml-indent-line` not being able to indent with tabs.

As an added bonus, this also fixes the `rjsx-indentation-1` test for Emacs < 26.