### PR TITLE
Feature: Jump to beginning and end of tag

### DIFF
--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -973,6 +973,48 @@ NEW-NAME is the name to give the tag."
 
 (define-key rjsx-mode-map (kbd "C-c C-r") 'rjsx-rename-tag-at-point)
 
+
+(defun rjsx-jump-closing-tag ()
+  "Goto closing tag of focused tab body"
+  (interactive)
+  (let* ((tag (rjsx--tag-at-point))
+         (closer (and tag (rjsx-node-closing-tag tag))))
+    (cond
+     ((null tag) (message "No JSX tag found at point"))
+     (t
+      (goto-char (+ 1 (js2-node-abs-pos closer)))
+     ))))
+
+
+(defun rjsx-jump-opening-tag ()
+  "Goto opening tag of focused tab body"
+  (interactive)
+  (let* ((tag (rjsx--tag-at-point))
+         (closer (and tag (rjsx-node-closing-tag tag))))
+    (cond
+     ((null tag) (message "No JSX tag found at point"))
+     (t
+      (goto-char (+ 1 (js2-node-abs-pos tag)))
+      ))))
+
+(defun rjsx-jump-tag ()
+   "Switch between opening and closing tag of focused tab body"
+  (interactive)
+  (let* ((tag (rjsx--tag-at-point))
+         (closer (and tag (rjsx-node-closing-tag tag))))
+    (cond
+     ((null tag) (message "No JSX tag found at point"))
+     ((null closer) (message "No closing JSX tag found at point"))
+     ((eq (line-number-at-pos (js2-node-abs-pos tag)) (line-number-at-pos)) (rjsx-jump-closing-tag))
+     ((eq (line-number-at-pos (js2-node-abs-pos closer)) (line-number-at-pos)) (rjsx-jump-opening-tag))
+     (t
+      (rjsx-jump-closing-tag)
+      ))))
+
+
+
+(define-key rjsx-mode-map (kbd "C-c C-g") 'rjsx-jump-tag)
+
 
 
 ;; Utilities

--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -1007,7 +1007,7 @@ NEW-NAME is the name to give the tag."
      ((eq (line-number-at-pos (js2-node-abs-pos tag)) (line-number-at-pos)) (rjsx-jump-closing-tag))
      ((eq (line-number-at-pos (js2-node-abs-pos closer)) (line-number-at-pos)) (rjsx-jump-opening-tag))
      (t
-      (rjsx-jump-closing-tag)))))
+      (rjsx-jump-opening-tag)))))
 
 
 

--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -981,6 +981,7 @@ NEW-NAME is the name to give the tag."
          (closer (and tag (rjsx-node-closing-tag tag))))
     (cond
      ((null tag) (message "No JSX tag found at point"))
+     ((null closer) (message "JSX tag is self closing"))
      (t
       (goto-char (+ 1 (js2-node-abs-pos closer)))))))
 

--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -982,23 +982,20 @@ NEW-NAME is the name to give the tag."
     (cond
      ((null tag) (message "No JSX tag found at point"))
      (t
-      (goto-char (+ 1 (js2-node-abs-pos closer)))
-     ))))
+      (goto-char (+ 1 (js2-node-abs-pos closer)))))))
 
 
 (defun rjsx-jump-opening-tag ()
   "Goto opening tag of focused tab body"
   (interactive)
-  (let* ((tag (rjsx--tag-at-point))
-         (closer (and tag (rjsx-node-closing-tag tag))))
+  (let* ((tag (rjsx--tag-at-point)))
     (cond
      ((null tag) (message "No JSX tag found at point"))
      (t
-      (goto-char (+ 1 (js2-node-abs-pos tag)))
-      ))))
+      (goto-char (+ 1 (js2-node-abs-pos tag)))))))
 
 (defun rjsx-jump-tag ()
-   "Switch between opening and closing tag of focused tab body"
+  "Switch between opening and closing tag of focused tab body"
   (interactive)
   (let* ((tag (rjsx--tag-at-point))
          (closer (and tag (rjsx-node-closing-tag tag))))
@@ -1008,12 +1005,11 @@ NEW-NAME is the name to give the tag."
      ((eq (line-number-at-pos (js2-node-abs-pos tag)) (line-number-at-pos)) (rjsx-jump-closing-tag))
      ((eq (line-number-at-pos (js2-node-abs-pos closer)) (line-number-at-pos)) (rjsx-jump-opening-tag))
      (t
-      (rjsx-jump-closing-tag)
-      ))))
+      (rjsx-jump-closing-tag)))))
 
 
 
-(define-key rjsx-mode-map (kbd "C-c C-g") 'rjsx-jump-tag)
+(define-key rjsx-mode-map (kbd "C-c C-j") 'rjsx-jump-tag)
 
 
 

--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -989,7 +989,8 @@ NEW-NAME is the name to give the tag."
 (defun rjsx-jump-opening-tag ()
   "Goto opening tag of focused tab body"
   (interactive)
-  (let* ((tag (rjsx--tag-at-point)))
+  (let* ((tag (rjsx--tag-at-point))
+         (closer (and tag (rjsx-node-closing-tag tag))))
     (cond
      ((null tag) (message "No JSX tag found at point"))
      (t

--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -975,7 +975,7 @@ NEW-NAME is the name to give the tag."
 
 
 (defun rjsx-jump-closing-tag ()
-  "Goto closing tag of focused tab body"
+  "Go to closing tag of tag at point."
   (interactive)
   (let* ((tag (rjsx--tag-at-point))
          (closer (and tag (rjsx-node-closing-tag tag))))

--- a/rjsx-tests.el
+++ b/rjsx-tests.el
@@ -1302,6 +1302,29 @@ on the same line number and POST-OFFSET columns in."
   (rjsx-tests--test-point-after-indent
    "const c = <div\n            abc={123}" "\n            def/>;" 9))
 
+(ert-deftest rjsx-jump-closing-tag ()
+  "Test that point is correctly placed on jumping to closing tag"
+  (ert-with-test-buffer (:name 'rjsx-jump-closing-tag)
+    (erase-buffer)
+    (insert "let c = <div")
+    (save-excursion (insert ">\n</div>"))
+    (rjsx-mode)
+    (rjsx-jump-closing-tag)
+    (should (= (line-number-at-pos) 2))
+    (should (= (current-column) 1))))
+
+
+(ert-deftest rjsx-jump-opening-tag ()
+  "Test that point is correctly placed on jumping to opening tag"
+  (ert-with-test-buffer (:name 'rjsx-jump-opening-tag)
+    (erase-buffer)
+    (insert "let c = <div>\n</div")
+    (save-excursion (insert ">"))
+    (rjsx-mode)
+    (rjsx-jump-opening-tag)
+    (should (= (line-number-at-pos) 1))
+    (should (= (current-column) 9))
+    ))
 
 ;; Minor-mode
 

--- a/rjsx-tests.el
+++ b/rjsx-tests.el
@@ -1325,6 +1325,22 @@ on the same line number and POST-OFFSET columns in."
     (should (= (line-number-at-pos) 1))
     (should (= (current-column) 9))
     ))
+
+
+(ert-deftest rjsx-jump-tag ()
+  "Test that point is correctly placed on jumping to opening tag"
+  (ert-with-test-buffer (:name 'rjsx-jump-opening-tag)
+    (erase-buffer)
+    (insert "let c = <div>\n</div")
+    (save-excursion (insert ">"))
+    (rjsx-mode)
+    (rjsx-jump-tag)
+    (should (= (line-number-at-pos) 1))
+    (should (= (current-column) 9))
+    (rjsx-jump-tag)
+    (should (= (line-number-at-pos) 2))
+    (should (= (current-column) 1))
+    ))
 
 ;; Minor-mode
 


### PR DESCRIPTION
**Description**
- In rjsx mode there is no way to jump to closing tag or beginning tag
- This PR adds three more interactive functions rjsx-jump-to-closing-tag, rjsx-jump-to-opening-tag and rjsx-jump-tag
- With rjsx-jump-tag we can alternate between beginning and end tag
- rjsx-jump-tag is bound to C-c C-j by default

**Reference**
Issue: #90