### PR TITLE
dont override user's tab preference

### DIFF
--- a/rjsx-mode.el
+++ b/rjsx-mode.el
@@ -1339,8 +1339,7 @@ Fixes:
 
 (defun rjsx--indent-line-1 ()
   "Helper for `rjsx-indent-line'."
-  (let* ((indent-tabs-mode nil)
-         (cur-pos (point))
+  (let* ((cur-pos (point))
          (cur-char (char-after cur-pos))
          (node (js2-node-at-point (- cur-pos rjsx--indent-running-offset)))
          (parent (js2-node-parent node)))


### PR DESCRIPTION
As mentioned in #85, eae8137 introduced a local override to `indent-tabs-mode` which (unexpectedly to the user) switches to spaces to indent. By simply removing that pair, indentation now works the way I expect. I didn't observe any other changes to indentation, though I would appreciate someone else who is more familiar with this code taking a look as well.

Fixes #85